### PR TITLE
fix: dont cast nan values to float

### DIFF
--- a/braze_user_csv_import/app.py
+++ b/braze_user_csv_import/app.py
@@ -295,17 +295,20 @@ def _process_value(
     if cast == str:
         return value
 
-    stripped = value.strip().lower()
-    leading_zero_int = len(stripped) > 1 and stripped.startswith('0') \
-        and not stripped.startswith('0.')
     if cast:
         return cast(_process_value(value))
 
+    stripped = value.strip().lower()
+    leading_zero_int = len(stripped) > 1 and stripped.startswith('0') \
+        and not stripped.startswith('0.')
+
+    is_numeric = stripped.replace('.', '').replace('-', '').isdigit()
+
     if stripped == 'null':
         return None
-    elif not leading_zero_int and _is_int(stripped):
+    elif is_numeric and not leading_zero_int and _is_int(stripped):
         return int(stripped)
-    elif not leading_zero_int and _is_float(stripped):
+    elif is_numeric and not leading_zero_int and _is_float(stripped):
         return float(stripped)
     elif stripped == 'true':
         return True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,6 +129,10 @@ def test__process_value_boolean():
     assert False == app._process_value("false")
 
 
+def test__process_value_null():
+    assert None == app._process_value("null")
+
+
 def test__process_value_array():
     assert [9.12, 1, 4] == app._process_value("[9.12, 1, 4]")
     assert ["a", "b", "c"] == app._process_value("['a', 'b', 'c']")
@@ -139,6 +143,10 @@ def test__process_value_starts_with_symbol():
     assert "[ex" == app._process_value("[ex")
     assert "<lol" == app._process_value("<lol")
     assert "str[he%l@@]" == app._process_value("str[he%l@@]")
+
+
+def test__process_value_nan_string():
+    assert 'nan' == app._process_value("nan")
 
 
 def test__process_value_force_cast_to_int():


### PR DESCRIPTION
`nan` can be cast to float in Python (means 'not a number'). Make sure that the value is numerical before trying to convert it to a float.

Closes #9.