### PR TITLE
Update app.py (reset stripped)

### DIFF
--- a/braze_user_csv_import/app.py
+++ b/braze_user_csv_import/app.py
@@ -314,6 +314,8 @@ def _process_value(
         return True
     elif stripped == 'false':
         return False
+    #reset stripped so case is preserved
+    stripped = value.strip()
     elif len(stripped) > 1 and stripped[0] == '[' and stripped[-1] == ']':
         try:
             return ast.literal_eval(stripped)


### PR DESCRIPTION
Added a line to reset the 'stripped' variable to preserve the case of the contents in an array by not including the .lower() used earlier in the _process_value function.