### PR TITLE
change Python runtime to 3.12 in template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -53,7 +53,7 @@ Resources:
       FunctionName: braze-user-csv-import
       CodeUri: braze_user_csv_import/
       Handler: app.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.12
       MemorySize: 2048
       EventInvokeConfig:
         MaximumRetryAttempts: 0


### PR DESCRIPTION
Unable to deploy in AWS with the Python 3.7 runtime.